### PR TITLE
Update deprecated login_headertitle filter in configuration login

### DIFF
--- a/src/LIN3S/WPFoundation/Configuration/Login/Login.php
+++ b/src/LIN3S/WPFoundation/Configuration/Login/Login.php
@@ -27,7 +27,7 @@ abstract class Login implements LoginInterface
         add_filter('login_errors', [$this, 'errors']);
         add_action('login_enqueue_scripts', [$this, 'logo']);
         add_filter('login_message', [$this, 'message']);
-        add_filter('login_headertitle', [$this, 'title']);
+        add_filter('login_headertext', [$this, 'title']);
         add_filter('login_headerurl', [$this, 'url']);
     }
 


### PR DESCRIPTION
Deprecated: login_headertitle ha quedado obsoleto desde la versión 5.2.0. Utiliza login_headertext en su lugar